### PR TITLE
Bugfix: Handle warning of date in unspecified format

### DIFF
--- a/src/Components/MainLayout/Modal/ExpenseForm.js
+++ b/src/Components/MainLayout/Modal/ExpenseForm.js
@@ -64,15 +64,18 @@ const ExpenseForm = ({ handleOnCancel, pickedDate, expenseItemDetails }) => {
       return;
     }
     setFormError(false);
-    expenseFormData.date = getDateFromDateString(
-      expenseFormData.date
-    ).toISOString();
+    const dataToSend = {
+      ...expenseFormData,
+      date: getDateFromDateString(
+        expenseFormData.date
+      ).toISOString()
+    }
 
     try {
       if (expenseItemDetails) {
-        await handleUpdateExpenseItem(expenseFormData, pickedDate);
+        await handleUpdateExpenseItem(dataToSend, pickedDate);
       } else {
-        await handleAddExpenseItem(expenseFormData, pickedDate);
+        await handleAddExpenseItem(dataToSend, pickedDate);
       }
       handleOnCancel();
       const notificationMessage = `${


### PR DESCRIPTION
Refactor the `handleFormSubmit` function in `ExpenseForm.js` to prevent changing the date directly to avoid the warning log of incorrect format for the HTML date input

![image](https://github.com/user-attachments/assets/7ea86433-edff-438d-b382-d9fb7c5fcdeb)
